### PR TITLE
refactor questions

### DIFF
--- a/packages/react-app/src/graphql/subgraph.ts
+++ b/packages/react-app/src/graphql/subgraph.ts
@@ -33,7 +33,7 @@ export const TOURNAMENT_FIELDS = `
 
 export interface Answer {
   id: string
-  answer: BigNumberish
+  answer: string
   historyHash: string
   user: string
   bond: BigNumberish
@@ -41,8 +41,6 @@ export interface Answer {
   isCommitment: boolean
   match: Match
   tournament: Tournament
-  isPendingArbitration: boolean
-  arbitrationOccurred: boolean
 }
 
 export interface Match {
@@ -57,7 +55,27 @@ export interface Match {
   minBond: BigNumberish
   contentHash: string
   historyHash: string
+  answerFinalizedTimestamp: string | null
+  isPendingArbitration: boolean
 }
+
+export const MATCH_FIELDS = `
+  fragment MatchFields on Match {
+    id
+    questionID
+    nonce
+    tournament{id}
+    answer{id, answer}
+    openingTs
+    finalizeTs
+    timeout
+    minBond
+    contentHash
+    historyHash
+    answerFinalizedTimestamp
+    isPendingArbitration
+  }
+`;
 
 export interface Player {
   id: string
@@ -91,22 +109,6 @@ export interface Funder {
   tournaments: [Tournament]
   messages: [string]
 }
-
-export const MATCH_FIELDS = `
-  fragment MatchFields on Match {
-    id
-    questionID
-    nonce
-    tournament{id}
-    answer{id, answer}
-    openingTs
-    finalizeTs
-    timeout
-    minBond
-    contentHash
-    historyHash
-  }
-`;
 
 export const PLAYER_FIELDS = `
   fragment PlayerFields on Player {
@@ -158,10 +160,6 @@ export interface Outcome {
 export interface Question {
   questionId: string
   qTitle: string
-  openingTimestamp: string
-  currentAnswer: string
-  isPendingArbitration: boolean
-  answerFinalizedTimestamp: string | null
   outcomes: Outcome[]
 }
 
@@ -169,10 +167,6 @@ export const QUESTION_FIELDS = `
   fragment QuestionFields on Question {
     questionId
     qTitle
-    openingTimestamp
-    currentAnswer
-    isPendingArbitration
-    answerFinalizedTimestamp
     outcomes {
       id
       answer

--- a/packages/react-app/src/hooks/useQuestions.ts
+++ b/packages/react-app/src/hooks/useQuestions.ts
@@ -15,7 +15,7 @@ const query = `
 export const useQuestions = (tournamentId: string) => {
   const {data: matches} = useMatches(tournamentId);
 
-  return useQuery<Question[], Error>(
+  return useQuery<Record<string, Question>, Error>(
     ["useQuestions", tournamentId],
     async () => {
       if (!matches) {
@@ -28,7 +28,9 @@ export const useQuestions = (tournamentId: string) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.questions;
+      return response.data.questions.reduce((obj, question) => {
+        return {...obj, [question.questionId]: question}
+      }, {})
     },
     {
       enabled: !!matches

--- a/packages/react-app/src/hooks/useTournamentStatus.ts
+++ b/packages/react-app/src/hooks/useTournamentStatus.ts
@@ -2,17 +2,17 @@ import { useQuery } from "react-query";
 import compareAsc from "date-fns/compareAsc";
 import fromUnixTime from "date-fns/fromUnixTime";
 import {useTournament} from "./useTournament";
-import {useQuestions} from "./useQuestions";
 import {isFinalized} from "../lib/helpers";
+import {useMatches} from "./useMatches";
 
 export const useTournamentStatus = (tournamentId: string) => {
   const {data: tournament} = useTournament(tournamentId)
-  const {data: questions} = useQuestions(tournamentId)
+  const {data: matches} = useMatches(tournamentId)
 
   return useQuery<string, Error>(
     ["useTournamentStatus", tournamentId],
     async () => {
-      if (!tournament || !questions) {
+      if (!tournament || !matches) {
         return '';
       }
 
@@ -21,7 +21,7 @@ export const useTournamentStatus = (tournamentId: string) => {
         return 'ACCEPTING_BETS';
       }
 
-      const hasPendingAnswers = questions.filter(q => !isFinalized(q)).length > 0
+      const hasPendingAnswers = matches.filter(q => !isFinalized(q)).length > 0
 
       if (hasPendingAnswers) {
         return 'WAITING_ANSWERS'
@@ -46,7 +46,7 @@ export const useTournamentStatus = (tournamentId: string) => {
       return 'FINALIZED';
     },
     {
-      enabled: !!tournament && !!questions
+      enabled: !!tournament && !!matches
     }
   );
 };

--- a/packages/react-app/src/lib/helpers.ts
+++ b/packages/react-app/src/lib/helpers.ts
@@ -5,7 +5,7 @@ import formatDuration from 'date-fns/formatDuration'
 import compareAsc from 'date-fns/compareAsc'
 import {BigNumber, BigNumberish} from "@ethersproject/bignumber";
 import {DecimalBigNumber} from "./DecimalBigNumber";
-import {Outcome, Question} from "../graphql/subgraph";
+import {Match, Outcome} from "../graphql/subgraph";
 
 export function formatDate(timestamp: number) {
   const date = fromUnixTime(timestamp);
@@ -49,10 +49,10 @@ export function getAnswerText(currentAnswer: string | null, outcomes: Outcome[],
 }
 
 // https://github.com/RealityETH/reality-eth-monorepo/blob/34fd0601d5d6f9be0aed41278bdf0b8a1211b5fa/packages/contracts/development/contracts/RealityETH-3.0.sol#L490
-export function isFinalized(question: Question) {
-  const finalizeTs = Number(question.answerFinalizedTimestamp);
+export function isFinalized(match: Match) {
+  const finalizeTs = Number(match.answerFinalizedTimestamp);
   return (
-    !question.isPendingArbitration
+    !match.isPendingArbitration
     && (finalizeTs > 0)
     && (compareAsc(new Date(), fromUnixTime(finalizeTs)) === 1)
   );

--- a/packages/react-app/src/pages/TournamentsView.tsx
+++ b/packages/react-app/src/pages/TournamentsView.tsx
@@ -10,11 +10,13 @@ import {formatAmount, getAnswerText, getTimeLeft, isFinalized} from "../lib/help
 import {useQuestions} from "../hooks/useQuestions";
 import {useTournamentStatus} from "../hooks/useTournamentStatus";
 import {DIVISOR} from "../components/TournamentCreate/TournamentForm";
+import {useMatches} from "../hooks/useMatches";
 
 function TournamentsView() {
   const { id } = useParams();
   const { isLoading, data: tournament } = useTournament(String(id));
   const { data: ranking } = useRanking(String(id));
+  const { data: matches } = useMatches(String(id));
   const { data: questions } = useQuestions(String(id));
   const { data: tournamentStatus} = useTournamentStatus(String(id));
   const [section, setSection] = useState<'ranking'|'results'>('ranking');
@@ -108,15 +110,15 @@ function TournamentsView() {
           <div style={{width: '30%'}}>Result</div>
           <div style={{width: '10%'}}>Status</div>
         </BoxRow>
-        {questions && questions.map((question, i) => {
+        {matches && matches.map((match, i) => {
           return <BoxRow style={{display: 'flex'}} key={i}>
             <div style={{width: '60%'}}>
-              <a href={`https://reality.eth.link/app/index.html#!/network/100/question/0xe78996a233895be74a66f451f1019ca9734205cc-${question.questionId}`} target="_blank" rel="noreferrer">
-                {question.qTitle}
+              <a href={`https://reality.eth.link/app/index.html#!/network/100/question/0xe78996a233895be74a66f451f1019ca9734205cc-${match.questionID}`} target="_blank" rel="noreferrer">
+                {questions?.[match.questionID].qTitle}
               </a>
             </div>
-            <div style={{width: '30%'}}>{getTimeLeft(question.openingTimestamp) || getAnswerText(question.currentAnswer, question.outcomes)}</div>
-            <div style={{width: '10%'}}>{isFinalized(question) ? 'Finalized' : 'Pending'}</div>
+            <div style={{width: '30%'}}>{getTimeLeft(match.openingTs) || getAnswerText(match.answer.answer, questions?.[match.questionID].outcomes || [])}</div>
+            <div style={{width: '10%'}}>{isFinalized(match) ? 'Finalized' : 'Pending'}</div>
           </BoxRow>
         })}
       </Box>}

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -28,6 +28,9 @@ type Match @entity {
   nonce: BigInt!
   tournament: Tournament!
   answer: Answer @derivedFrom(field: "match")
+  answerFinalizedTimestamp: BigInt
+  arbitrationOccurred: Boolean!
+  isPendingArbitration: Boolean!
   openingTs: BigInt!,
   finalizeTs: BigInt!,
   timeout: BigInt!,
@@ -48,8 +51,6 @@ type Answer @entity {
   isCommitment: Boolean!
   match: Match!
   tournament: Tournament!
-  isPendingArbitration: Boolean!
-  arbitrationOccurred: Boolean!
 }
 
 type Player @entity {

--- a/packages/subgraph/src/mappings/Tournament.ts
+++ b/packages/subgraph/src/mappings/Tournament.ts
@@ -48,6 +48,8 @@ export function handleQuestionsRegistered(event: QuestionsRegistered): void {
         match.finalizeTs = realitioSC.getFinalizeTS(questionID);
         match.contentHash = realitioSC.getContentHash(questionID);
         match.historyHash = realitioSC.getHistoryHash(questionID);
+        match.arbitrationOccurred = false;
+        match.isPendingArbitration = false;
         match.save();
         nonce = nonce.plus(BigInt.fromI32(1))
         log.debug("handleQuestionsRegistered: matchID {} registered", [questionID.toHexString()])


### PR DESCRIPTION
This PR:

- moves `isPendingArbitration` and `arbitrationOccurred` from `Anwer` to `Match`
- uses the reality.eth subgraph only to read the questions titles and outcomes (everything else should be in our subgraph)
- changes the `useQuestions` hook to make it simpler to get the title of a given questionId