### PR TITLE
refactor answers

### DIFF
--- a/packages/react-app/src/graphql/subgraph.ts
+++ b/packages/react-app/src/graphql/subgraph.ts
@@ -31,24 +31,12 @@ export const TOURNAMENT_FIELDS = `
     }
 `;
 
-export interface Answer {
-  id: string
-  answer: string
-  historyHash: string
-  user: string
-  bond: BigNumberish
-  timestamp: string
-  isCommitment: boolean
-  match: Match
-  tournament: Tournament
-}
-
 export interface Match {
   id: string
   questionID: string
   nonce: BigNumberish
   tournament: Tournament
-  answer: Answer | null
+  answer: string | null
   openingTs: string
   finalizeTs: string
   timeout: string
@@ -65,7 +53,7 @@ export const MATCH_FIELDS = `
     questionID
     nonce
     tournament{id}
-    answer{id, answer}
+    answer
     openingTs
     finalizeTs
     timeout
@@ -93,9 +81,7 @@ export interface Bet {
     name: string
     matches: {
       questionID: string
-      answer: {
-        answer: string
-      } | null
+      answer: string | null
     }[]
   }
   tokenID: BigNumberish
@@ -117,9 +103,7 @@ export const BET_FIELDS = `
       name,
       matches {
         questionID
-        answer {
-          answer
-        }
+        answer
       }
     }
     tokenID
@@ -151,9 +135,7 @@ export const PLAYER_FIELDS = `
         id
         name
         matches{
-          answer{
-            answer
-          }
+          answer
           id
         }
       }

--- a/packages/react-app/src/pages/Profile.tsx
+++ b/packages/react-app/src/pages/Profile.tsx
@@ -18,7 +18,7 @@ function BetDetails({bet}: {bet: Bet}) {
     </BoxRow>
     {bet.tournament.matches.map((match, i) => {
       let betResult = getAnswerText(bet.results[i], questions?.[match.questionID].outcomes || []);
-      let matchResult = getAnswerText(match.answer?.answer || null, questions?.[match.questionID].outcomes || [], "Unknown");
+      let matchResult = getAnswerText(match.answer, questions?.[match.questionID].outcomes || [], "Unknown");
 
       return <BoxRow key={i}>
         <div style={{ width: '40%', wordBreak: 'break-word' }}>{betResult}</div>

--- a/packages/react-app/src/pages/TournamentsView.tsx
+++ b/packages/react-app/src/pages/TournamentsView.tsx
@@ -117,7 +117,7 @@ function TournamentsView() {
                 {questions?.[match.questionID].qTitle}
               </a>
             </div>
-            <div style={{width: '30%'}}>{getTimeLeft(match.openingTs) || getAnswerText(match.answer?.answer || null, questions?.[match.questionID].outcomes || [])}</div>
+            <div style={{width: '30%'}}>{getTimeLeft(match.openingTs) || getAnswerText(match.answer, questions?.[match.questionID].outcomes || [])}</div>
             <div style={{width: '10%'}}>{isFinalized(match) ? 'Finalized' : 'Pending'}</div>
           </BoxRow>
         })}

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -27,7 +27,7 @@ type Match @entity {
   questionID: Bytes!
   nonce: BigInt!
   tournament: Tournament!
-  answer: Answer @derivedFrom(field: "match")
+  answer: Bytes
   answerFinalizedTimestamp: BigInt
   arbitrationOccurred: Boolean!
   isPendingArbitration: Boolean!
@@ -37,20 +37,6 @@ type Match @entity {
   minBond: BigInt!,
   contentHash: Bytes!
   historyHash: Bytes!
-}
-
-type Answer @entity {
-  "questionID"
-  id: ID!
-  "Answer expresed in uint"
-  answer: Bytes!,
-  historyHash: Bytes!
-  user: Bytes!,
-  bond: BigInt!,
-  timestamp: BigInt!,
-  isCommitment: Boolean!
-  match: Match!
-  tournament: Tournament!
 }
 
 type Player @entity {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -13,8 +13,6 @@ type Tournament @entity {
   managementFee: BigInt
   manager: Manager!
   numOfMatches: BigInt!
-  numOfMatchesWithAnswer: BigInt!
-  hasPendingAnswers: Boolean!
   players: [Player!]! @derivedFrom(field: "tournaments")
   matches: [Match!]! @derivedFrom(field: "tournament")
   bets: [Bet!]! @derivedFrom(field: "tournament")

--- a/packages/subgraph/src/mappings/Realitio.ts
+++ b/packages/subgraph/src/mappings/Realitio.ts
@@ -1,6 +1,6 @@
 import { BigInt, ByteArray, Bytes, log } from "@graphprotocol/graph-ts";
 import { LogFinalize, LogNewAnswer, LogNotifyOfArbitrationRequest } from "../types/RealitioV3/Realitio";
-import { Answer, Bet, Match, Tournament } from "../types/schema";
+import { Bet, Match, Tournament } from "../types/schema";
 import { correctAnswerPoints } from "./constants";
 import { getBetID } from "./helpers";
 
@@ -11,27 +11,17 @@ export function handleNewAnswer(event: LogNewAnswer): void {
 
     const ts = event.params.ts;
     match.answerFinalizedTimestamp = match.arbitrationOccurred ? ts : ts.plus(match.timeout);
-    match.save();
 
-    let answerEntity = Answer.load(id);
     let changeAnswer = false;
-    let oldAnswer : Bytes
-    if (answerEntity === null) {
-        answerEntity = new Answer(id);
-    } else {
-        // the answer it's changing
+    let oldAnswer: Bytes;
+    let tmpAnswer = match.answer;
+    if (tmpAnswer !== null) {
+        // the answer is changing
         changeAnswer = true;
-        oldAnswer = answerEntity.answer;
+        oldAnswer = tmpAnswer;
     }
-    answerEntity.answer = event.params.answer
-    answerEntity.bond = event.params.bond;
-    answerEntity.historyHash = event.params.history_hash;
-    answerEntity.isCommitment = event.params.is_commitment;
-    answerEntity.user = event.params.user;
-    answerEntity.timestamp = event.params.ts;
-    answerEntity.match = match.id;
-    answerEntity.tournament = match.tournament;
-    answerEntity.save();
+    match.answer = event.params.answer
+    match.save();
 
     if (!changeAnswer) {
         let tournament = Tournament.load(match.tournament)!;
@@ -46,12 +36,12 @@ export function handleNewAnswer(event: LogNewAnswer): void {
     let tokenID = BigInt.fromI32(0);
     const questionNonce = match.nonce;
     let tournamentId = ByteArray.fromHexString(match.tournament);
-    log.debug("handleNewAnswer: summing points for tournament {}, questoinID: {}, questionNonce: {}, with answer {}", [tournamentId.toHexString(), id, questionNonce.toString(),answerEntity.answer.toHexString()]);
+    log.debug("handleNewAnswer: summing points for tournament {}, questoinID: {}, questionNonce: {}, with answer {}", [tournamentId.toHexString(), id, questionNonce.toString(),match.answer!.toHexString()]);
     let betID = getBetID(tournamentId, tokenID);
     let bet = Bet.load(betID);
     while (bet !== null) {
         let betResult = bet.results[questionNonce.toI32()];
-        if (betResult.equals(answerEntity.answer)) {
+        if (betResult.equals(match.answer!)) {
             // The player has the correct answer
             log.debug("handleNewAnswer: Bet {} has correct answer.", [betID.toString()]);
             bet.points = bet.points.plus(correctAnswerPoints);
@@ -81,14 +71,11 @@ export function handleArbitrationRequest(event: LogNotifyOfArbitrationRequest): 
 }
 
 export function handleFinalize(event: LogFinalize): void {
-    let answer = Answer.load(event.params.question_id.toHexString());
-    if (answer === null) return; // not a question for our tournaments
-    log.debug("handleArbitrationRequest: Dispute raise for answer {}", [answer.id]);
+    let match = Match.load(event.params.question_id.toHexString());
+    if (match === null) return; // not a question for our tournaments
+    log.debug("handleArbitrationRequest: Dispute raise for question {}", [match.id]);
 
-    answer.answer = event.params.answer;
-    answer.save();
-
-    let match = Match.load(event.params.question_id.toHexString())!;
+    match.answer = event.params.answer;
     match.isPendingArbitration = false;
     match.arbitrationOccurred = true;
     match.save();

--- a/packages/subgraph/src/mappings/Realitio.ts
+++ b/packages/subgraph/src/mappings/Realitio.ts
@@ -23,15 +23,6 @@ export function handleNewAnswer(event: LogNewAnswer): void {
     match.answer = event.params.answer
     match.save();
 
-    if (!changeAnswer) {
-        let tournament = Tournament.load(match.tournament)!;
-        tournament.numOfMatchesWithAnswer = tournament.numOfMatchesWithAnswer.plus(BigInt.fromI32(1));
-        // will be true even if this is not a final answer
-        log.debug("handleNewAnswer: num of answers == num of matches? {}", [tournament.numOfMatchesWithAnswer.equals(tournament.numOfMatches).toString()]);
-        tournament.hasPendingAnswers = !tournament.numOfMatchesWithAnswer.equals(tournament.numOfMatches);
-        tournament.save();
-    }
-
     // update points with this answer.
     let tokenID = BigInt.fromI32(0);
     const questionNonce = match.nonce;

--- a/packages/subgraph/src/mappings/Tournament.ts
+++ b/packages/subgraph/src/mappings/Tournament.ts
@@ -21,8 +21,6 @@ export function handleInitialize(event: Initialize): void {
     tournament.price = event.params._price;
     tournament.owner = event.params._ownwer;
     tournament.numOfMatches = BigInt.fromI32(0);
-    tournament.numOfMatchesWithAnswer = BigInt.fromI32(0);
-    tournament.hasPendingAnswers = true;
 
     let manager = getOrCreateManager(event.params._manager);
     tournament.manager = manager.id;


### PR DESCRIPTION
This PR:

- Removes de `Answer` entity and replaces it with a `Bytes` answer field. It was a one-to-one relationship with `Match`, and the only field that we were using was `answer.answer`.
- This simplification allows us to use `match.answer` in the frontend without the need of a non-null check in `match.answer !== null ? match.answer.answer : null` and simplifies the graphql querys (`{answer}` instead of `{answer: {answer}}`)
- `numOfMatchesWithAnswer` and `hasPendingAnswers` were not used anywhere, but if they are needed the query is easy to do.