### PR TITLE
Referral Claims, Manager Rewards and Duplicate Markets.

### DIFF
--- a/packages/react-app/src/components/MarketView/Results.tsx
+++ b/packages/react-app/src/components/MarketView/Results.tsx
@@ -153,7 +153,7 @@ export default function Results({marketId}: {marketId: string}) {
     setOpenModal(false);
     if (currentEvent) {
       // refetch events and question just in case the user has provided an answer
-      queryClient.invalidateQueries(['useEvents', currentEvent.market.id]);
+      queryClient.invalidateQueries(['useEvents', currentEvent.markets[0].id]);
       queryClient.invalidateQueries(['useQuestion', process.env.REACT_APP_REALITIO as string, currentEvent.id]);
     }
   }

--- a/packages/react-app/src/components/MarketView/Stats.tsx
+++ b/packages/react-app/src/components/MarketView/Stats.tsx
@@ -28,6 +28,7 @@ function bets2Stats(bets: Bet[]): Stat[][] {
         stat.push({ outcome: t`Invalid`, amountBets: 0, percentage: 0, index: 257, title: event.title, openingTs: event.openingTs })
         return stat
     })
+    if (stats.length === 0) return [];
     // Add stats
     bets.forEach((bet) => {
         bet.results.forEach((result, i) => {
@@ -59,7 +60,6 @@ function bets2Stats(bets: Bet[]): Stat[][] {
 }
 
 function statsBarsVertical(events: Stat[]) {
-    console.log(events.length)
     return (
         <BarChart data={events} layout='vertical'>
             <XAxis hide type="number" />

--- a/packages/react-app/src/components/ProfileView/Referrals.tsx
+++ b/packages/react-app/src/components/ProfileView/Referrals.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { shortenAddress } from "@usedapp/core";
 import Alert from "@mui/material/Alert";
-import { Trans } from "@lingui/macro";
-import { Grid, Skeleton } from "@mui/material";
+import { Trans, t } from "@lingui/macro";
+import { Button, Grid, Skeleton } from "@mui/material";
 import { formatAmount } from "../../lib/helpers";
 import { BoxRow } from "..";
 import { useAttributions } from "../../hooks/useAttributions";
@@ -26,15 +26,17 @@ export function Referrals({ provider }: { provider: string }) {
             <Grid item sm={12} md={12}>
                 <BoxRow>
                     <div style={{ width: '40%' }}><Trans>Referred</Trans></div>
-                    <div style={{ width: '40%' }}><Trans>Market</Trans></div>
-                    <div style={{ width: '20%' }}><Trans>Earn</Trans></div>
+                    <div style={{ width: '25%' }}><Trans>Market</Trans></div>
+                    <div style={{ width: '15%' }}><Trans>Earn</Trans></div>
+                    <div style={{ width: '20%' }}><Trans>Claim</Trans></div>
                 </BoxRow>
 
                 {referrals && referrals.map(refer => {
                     return (<BoxRow key={refer.id}>
                         <div style={{ width: '40%' }}>{shortenAddress(refer.attributor.id)}</div>
-                        <div style={{ width: '40%' }}><a href={'/#/markets/' + refer.market.id}>{refer.market.name}</a></div>
-                        <div style={{ width: '20%' }}>{formatAmount(refer.amount)}</div>
+                        <div style={{ width: '25%' }}><a href={'/#/markets/' + refer.market.id}>{refer.market.name}</a></div>
+                        <div style={{ width: '15%' }}>{formatAmount(refer.amount)}</div>
+                        <div style={{ width: '20%' }}>{refer.claimed? t`Claimed` : <Button><Trans>Claim</Trans></Button>}</div>
                     </BoxRow>
                     )
                 })}

--- a/packages/react-app/src/components/ProfileView/Referrals.tsx
+++ b/packages/react-app/src/components/ProfileView/Referrals.tsx
@@ -25,7 +25,7 @@ function ReferralDetail({ marketReferral }: { marketReferral: MarketReferral }) 
         send(manager);
     };
 
-    return (<Accordion key={marketReferral.id}>
+    return (<Accordion>
         <AccordionSummary
             expandIcon={<ExpandMoreOutlined />}
             aria-controls="panel1a-content"
@@ -83,7 +83,7 @@ export function Referrals({ provider }: { provider: string }) {
                 </BoxRow>
 
                 {marketsReferrals && marketsReferrals.map(mr => {
-                    return <ReferralDetail marketReferral={mr} />
+                    return <ReferralDetail marketReferral={mr} key={mr.id}/>
                 })}
             </Grid>
         </Grid>

--- a/packages/react-app/src/components/ProfileView/Referrals.tsx
+++ b/packages/react-app/src/components/ProfileView/Referrals.tsx
@@ -10,7 +10,6 @@ import { ExpandMoreOutlined } from "@mui/icons-material";
 import { shortenAddress, useContractFunction } from "@usedapp/core";
 import { Contract } from "@ethersproject/contracts";
 import { Manager__factory } from "../../typechain";
-import { Box } from "@mui/system";
 
 
 function ReferralDetail({ marketReferral }: { marketReferral: MarketReferral }) {
@@ -21,7 +20,7 @@ function ReferralDetail({ marketReferral }: { marketReferral: MarketReferral }) 
     const theme = useTheme();
 
     const { send, state } = useContractFunction(new Contract(marketReferral.manager, Manager__factory.createInterface()), 'claimReferralReward');
-    console.log(state)
+
     const handleClaimOnClick = (manager: string) => {
         send(manager);
     };
@@ -44,7 +43,6 @@ function ReferralDetail({ marketReferral }: { marketReferral: MarketReferral }) 
                     </div>
         </AccordionSummary>
         <AccordionDetails>
-            <Box    >
             {marketReferral.attributions.map((attribution) => {
                 return <BoxRow key={attribution.id}>
                     <div style={{ width: '80%' }}>{shortenAddress(attribution.attributor.id)}</div>
@@ -52,7 +50,6 @@ function ReferralDetail({ marketReferral }: { marketReferral: MarketReferral }) 
                 </BoxRow>
             })
            }
-           </Box>
         </AccordionDetails>
     </Accordion>
     )
@@ -78,7 +75,7 @@ export function Referrals({ provider }: { provider: string }) {
     return (
         <Grid container columnSpacing={2} rowSpacing={1} sx={{ marginTop: '30px', marginBottom: '30px'}}>
             <Grid item sm={12} md={12}>
-                <BoxRow>
+                <BoxRow key='header'>
                     <div style={{ width: '60%' }}><Trans>Market</Trans></div>
                     <div style={{ width: '15%' }}><Trans>Earn</Trans></div>
                     <div style={{ width: '20%' }}><Trans>Claim</Trans></div>

--- a/packages/react-app/src/components/ProfileView/Referrals.tsx
+++ b/packages/react-app/src/components/ProfileView/Referrals.tsx
@@ -1,14 +1,19 @@
 import React from "react";
-import { shortenAddress } from "@usedapp/core";
 import Alert from "@mui/material/Alert";
 import { Trans, t } from "@lingui/macro";
 import { Button, Grid, Skeleton } from "@mui/material";
 import { formatAmount } from "../../lib/helpers";
 import { BoxRow } from "..";
-import { useAttributions } from "../../hooks/useAttributions";
+import { useMarketReferrals } from "../../hooks/useMarketReferrals";
+
+
 
 export function Referrals({ provider }: { provider: string }) {
-    const { data: referrals, error, isLoading } = useAttributions({ provider });
+    const { data: marketsReferrals, error, isLoading } = useMarketReferrals({ provider });
+
+    const handleClaimOnClick = (manager: string) => {
+        // TODO: claim the referrals rewards from the manager contract
+    };
 
     if (error) {
         return <Alert severity="error">{error}</Alert>
@@ -18,29 +23,27 @@ export function Referrals({ provider }: { provider: string }) {
         return <Skeleton animation="wave" height={150} />
     }
 
-    if (!referrals || referrals.length === 0) {
+    if (!marketsReferrals || marketsReferrals.length === 0) {
         return <Alert severity="info"><Trans>Start referring into markets and earn part of the fees that your referred pays.</Trans></Alert>
     }
     return (
-        <Grid container columnSpacing={2} rowSpacing={1} sx={{ marginTop: '30px' }}>
+        <Grid container columnSpacing={2} rowSpacing={1} sx={{ marg7nTop: '30px' }}>
             <Grid item sm={12} md={12}>
                 <BoxRow>
-                    <div style={{ width: '40%' }}><Trans>Referred</Trans></div>
-                    <div style={{ width: '25%' }}><Trans>Market</Trans></div>
-                    <div style={{ width: '15%' }}><Trans>Earn</Trans></div>
+                    <div style={{ width: '40%' }}><Trans>Market</Trans></div>
+                    <div style={{ width: '20%' }}><Trans>Earn</Trans></div>
                     <div style={{ width: '20%' }}><Trans>Claim</Trans></div>
                 </BoxRow>
 
-                {referrals && referrals.map(refer => {
-                    return (<BoxRow key={refer.id}>
-                        <div style={{ width: '40%' }}>{shortenAddress(refer.attributor.id)}</div>
-                        <div style={{ width: '25%' }}><a href={'/#/markets/' + refer.market.id}>{refer.market.name}</a></div>
-                        <div style={{ width: '15%' }}>{formatAmount(refer.amount)}</div>
-                        <div style={{ width: '20%' }}>{refer.claimed? t`Claimed` : <Button><Trans>Claim</Trans></Button>}</div>
+                {marketsReferrals && marketsReferrals.map(mr => {
+                    return (<BoxRow>
+                        <div style={{ width: '40%' }}><a href={'/#/marketsReferrals/' + mr.market.id}>{mr.market.name}</a></div>
+                        <div style={{ width: '20%' }}>{formatAmount(mr.totalAmount)}</div>
+                        <div style={{ width: '20%' }}>{mr.claimed ? t`Already Claimed`+'!' : <Button onClick={() => handleClaimOnClick(mr.manager)}><Trans>Claim</Trans></Button>}</div>
                     </BoxRow>
                     )
                 })}
             </Grid>
         </Grid>
-    )    
+    )
 }

--- a/packages/react-app/src/components/ProfileView/Referrals.tsx
+++ b/packages/react-app/src/components/ProfileView/Referrals.tsx
@@ -1,19 +1,68 @@
 import React from "react";
 import Alert from "@mui/material/Alert";
 import { Trans, t } from "@lingui/macro";
-import { Button, Grid, Skeleton } from "@mui/material";
+import { Accordion, AccordionDetails, AccordionSummary, Button, CircularProgress, Grid, Skeleton, Typography, useTheme } from "@mui/material";
 import { formatAmount } from "../../lib/helpers";
 import { BoxRow } from "..";
 import { useMarketReferrals } from "../../hooks/useMarketReferrals";
+import { MarketReferral } from "../../graphql/subgraph";
+import { ExpandMoreOutlined } from "@mui/icons-material";
+import { shortenAddress, useContractFunction } from "@usedapp/core";
+import { Contract } from "@ethersproject/contracts";
+import { Manager__factory } from "../../typechain";
+import { Box } from "@mui/system";
 
+
+function ReferralDetail({ marketReferral }: { marketReferral: MarketReferral }) {
+    const [expand, setExpand] = React.useState(false);
+    const toggleAcordion = () => {
+        setExpand((prev) => !prev);
+    };
+    const theme = useTheme();
+
+    const { send, state } = useContractFunction(new Contract(marketReferral.manager, Manager__factory.createInterface()), 'claimReferralReward');
+    console.log(state)
+    const handleClaimOnClick = (manager: string) => {
+        send(manager);
+    };
+
+    return (<Accordion key={marketReferral.id}>
+        <AccordionSummary
+            expandIcon={<ExpandMoreOutlined />}
+            aria-controls="panel1a-content"
+            onClick={toggleAcordion}
+        >
+            <div style={{ width: '60%' }}><a href={'/#/marketsReferrals/' + marketReferral.market.id}>{marketReferral.market.name}</a></div>
+            <div style={{ width: '15%' }}>{formatAmount(marketReferral.totalAmount)}</div>
+            <div style={{ width: '25%' }}>{
+                marketReferral.claimed || state.status === 'Success' ? t`Already Claimed` + '!'
+                : state.status === 'Mining'
+                    ? <CircularProgress />
+                    : <div style={{display:'flex'}}>
+                        <Button onClick={() => handleClaimOnClick(marketReferral.manager)}><Trans>Claim</Trans></Button>
+                        {state.status === 'Exception'? <Typography sx={{color: theme.palette.error.main, marginLeft: '10px'}}><Trans>Error</Trans></Typography> : null}</div>}
+                    </div>
+        </AccordionSummary>
+        <AccordionDetails>
+            <Box    >
+            {marketReferral.attributions.map((attribution) => {
+                return <BoxRow key={attribution.id}>
+                    <div style={{ width: '80%' }}>{shortenAddress(attribution.attributor.id)}</div>
+                    <div style={{ width: '20%' }}>{formatAmount(attribution.amount)}</div>
+                </BoxRow>
+            })
+           }
+           </Box>
+        </AccordionDetails>
+    </Accordion>
+    )
+}
 
 
 export function Referrals({ provider }: { provider: string }) {
     const { data: marketsReferrals, error, isLoading } = useMarketReferrals({ provider });
 
-    const handleClaimOnClick = (manager: string) => {
-        // TODO: claim the referrals rewards from the manager contract
-    };
+
 
     if (error) {
         return <Alert severity="error">{error}</Alert>
@@ -27,21 +76,17 @@ export function Referrals({ provider }: { provider: string }) {
         return <Alert severity="info"><Trans>Start referring into markets and earn part of the fees that your referred pays.</Trans></Alert>
     }
     return (
-        <Grid container columnSpacing={2} rowSpacing={1} sx={{ marg7nTop: '30px' }}>
+        <Grid container columnSpacing={2} rowSpacing={1} sx={{ marginTop: '30px', marginBottom: '30px'}}>
             <Grid item sm={12} md={12}>
                 <BoxRow>
-                    <div style={{ width: '40%' }}><Trans>Market</Trans></div>
-                    <div style={{ width: '20%' }}><Trans>Earn</Trans></div>
+                    <div style={{ width: '60%' }}><Trans>Market</Trans></div>
+                    <div style={{ width: '15%' }}><Trans>Earn</Trans></div>
                     <div style={{ width: '20%' }}><Trans>Claim</Trans></div>
+                    <div style={{ width: '5%' }}></div>
                 </BoxRow>
 
                 {marketsReferrals && marketsReferrals.map(mr => {
-                    return (<BoxRow>
-                        <div style={{ width: '40%' }}><a href={'/#/marketsReferrals/' + mr.market.id}>{mr.market.name}</a></div>
-                        <div style={{ width: '20%' }}>{formatAmount(mr.totalAmount)}</div>
-                        <div style={{ width: '20%' }}>{mr.claimed ? t`Already Claimed`+'!' : <Button onClick={() => handleClaimOnClick(mr.manager)}><Trans>Claim</Trans></Button>}</div>
-                    </BoxRow>
-                    )
+                    return <ReferralDetail marketReferral={mr} />
                 })}
             </Grid>
         </Grid>

--- a/packages/react-app/src/graphql/subgraph.ts
+++ b/packages/react-app/src/graphql/subgraph.ts
@@ -134,6 +134,38 @@ export const ATTRIBUTION_FIELDS = `
   }
 `;
 
+export interface MarketReferral {
+  id: string
+  market: {
+    id: string,
+    name: string
+  }
+  totalAmount: BigNumberish
+  provider: {
+    id: string
+  }
+  claimed: boolean
+  manager: string
+  attributions: [{
+    id: string
+    attributor: {id: string}
+    amount: BigNumberish
+  }]
+}
+
+
+export const MARKETREFERRAL_FIELDS = `
+  fragment MarketReferralFields on MarketReferral {
+    id
+    market{id, name}
+    provider{id}
+    totalAmount
+    attributions{id, attributor{id}, amount}
+    claimed
+    manager
+  }
+`;
+
 export interface Leaderboard extends Player {
   numOfMarkets: string
   numOfBets: string

--- a/packages/react-app/src/graphql/subgraph.ts
+++ b/packages/react-app/src/graphql/subgraph.ts
@@ -55,9 +55,9 @@ export interface Event {
   id: string
   nonce: BigNumberish
   arbitrator: string
-  market: {
+  markets: [{
     id: string
-  }
+  }]
   category: string
   title: string
   answer: string | null
@@ -76,7 +76,7 @@ export const EVENT_FIELDS = `
     id
     nonce
     arbitrator
-    market{id}
+    markets{id}
     category
     title
     answer

--- a/packages/react-app/src/graphql/subgraph.ts
+++ b/packages/react-app/src/graphql/subgraph.ts
@@ -119,6 +119,7 @@ export interface Attribution {
     id: string
   }
   timestamp: BigNumberish
+  claimed: boolean
 }
 
 
@@ -129,6 +130,7 @@ export const ATTRIBUTION_FIELDS = `
     amount
     attributor{id}
     timestamp
+    claimed
   }
 `;
 

--- a/packages/react-app/src/hooks/useEvents.ts
+++ b/packages/react-app/src/hooks/useEvents.ts
@@ -7,7 +7,7 @@ import {indexObjectsByKey} from "../lib/helpers";
 const query = `
     ${EVENT_FIELDS}
     query EventsQuery ($marketId: String!, $orderBy: String!, $orderDirection: String!){
-      events(where:{market: $marketId}, orderBy: $orderBy, orderDirection: $orderDirection) {
+      events(where:{markets_contains: [$marketId]}, orderBy: $orderBy, orderDirection: $orderDirection) {
         ...EventFields
       }
     }

--- a/packages/react-app/src/hooks/useMarketReferrals.ts
+++ b/packages/react-app/src/hooks/useMarketReferrals.ts
@@ -1,0 +1,32 @@
+import {MarketReferral, MARKETREFERRAL_FIELDS} from "../graphql/subgraph";
+import {useQuery} from "@tanstack/react-query";
+import {apolloProdeQuery} from "../lib/apolloClient";
+import {buildQuery} from "../lib/SubgraphQueryBuilder";
+
+const query = `
+    ${MARKETREFERRAL_FIELDS}
+    query MarketReferralsQuery(#params#) {
+      marketReferrals(where: {#where#}) {
+        ...MarketReferralFields
+      }
+    }
+`;
+
+interface Props {
+  provider: string
+}
+
+export const useMarketReferrals = ({provider}: Props) => {
+  return useQuery<MarketReferral[], Error>(
+    ["useMarketReferrals", provider],
+    async () => {
+      const variables = {provider: provider.toLowerCase()};
+      const response = await apolloProdeQuery<{ marketReferrals: MarketReferral[] }>(buildQuery(query, variables), variables);
+      
+      if (!response) throw new Error("No response from TheGraph");
+      
+      return response.data.marketReferrals;
+    },
+    {enabled: !!provider}
+  );
+};

--- a/packages/react-app/src/lib/__tests__/brackets.test.ts
+++ b/packages/react-app/src/lib/__tests__/brackets.test.ts
@@ -5,9 +5,9 @@ function getMockEvent(id: string, title: string, outcomes: Outcome[]): Event {
   return {
     id: id,
     nonce: 0,
-    market: {
+    markets: [{
       id: '1',
-    },
+    }],
     title: title,
     answer: null,
     outcomes: outcomes,
@@ -17,6 +17,9 @@ function getMockEvent(id: string, title: string, outcomes: Outcome[]): Event {
     minBond: '0',
     lastBond: '0',
     bounty: '0',
+    arbitrator: '',
+    category: '',
+    timeout: '0'
   }
 }
 

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -31,7 +31,7 @@ type Market @entity {
   prizes: [BigInt!]
   curated: Boolean!
   players: [Player!]! @derivedFrom(field: "markets")
-  events: [Event!]! @derivedFrom(field: "market")
+  events: [Event!]! @derivedFrom(field: "markets")
   bets: [Bet!]! @derivedFrom(field: "market")
   funders: [Funder!] @derivedFrom(field: "markets")
   attributions: [Attribution!]! @derivedFrom(field: "market")
@@ -93,7 +93,7 @@ type Event @entity {
   id: ID!
   nonce: BigInt!
   arbitrator: Bytes!
-  market: Market!
+  markets: [Market!]!
   answer: Bytes
   category: String!
   title: String!

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -63,6 +63,7 @@ type CurateItem @entity {
 }
 
 type Attribution @entity {
+  "provider-attributor-market-counter"
   id: ID!
   "Wallet that receives the attribution"
   provider: Player!,
@@ -74,6 +75,7 @@ type Attribution @entity {
   market: Market!
   "timestamp of the attribution"
   timestamp: BigInt!
+  claimed: Boolean!
 }
 
 type Event @entity {
@@ -118,6 +120,7 @@ type Manager @entity {
   id: ID!
   markets: [Market!]!
   managementRewards: BigInt!
+  claimed: Boolean!
 }
 
 type Bet @entity {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -78,6 +78,16 @@ type Attribution @entity {
   claimed: Boolean!
 }
 
+type MarketReferral @entity {
+  id: ID!
+  provider: Player!
+  totalAmount: BigInt!
+  claimed: Boolean!
+  market: Market!
+  attributions: [Attribution!]!
+  manager: String!
+}
+
 type Event @entity {
   "questionID"
   id: ID!

--- a/packages/subgraph/src/mappings/Manager.ts
+++ b/packages/subgraph/src/mappings/Manager.ts
@@ -1,20 +1,23 @@
 import { log } from '@graphprotocol/graph-ts';
 import { Attribution } from '../types/schema';
 import { ClaimReferralRewardCall, DistributeRewardsCall } from '../types/templates/Manager/Manager';
-import { getAttributionID, getOrCreateManager } from './utils/helpers';
+import { getAttributionID, getLastAttributionId, getOrCreateManager } from './utils/helpers';
 
 
 export function handleClaimReferralReward(call: ClaimReferralRewardCall): void {
     let i = 0;
-    let attributionId = getAttributionID(call.transaction.from, call.inputs._referral, i.toString())
-    let attribution = Attribution.load(attributionId);
-    while (attribution !== null) {
+    const endId = getLastAttributionId(call.transaction.from.toHexString(), call.inputs._referral.toHexString())
+        
+    for (i; i<=endId; i++) {
+        let attributionId = getAttributionID(call.transaction.from.toHexString(), call.inputs._referral.toHexString(), i)
+        let attribution = Attribution.load(attributionId);
+        if (attribution === null) {
+            log.error("There is an error in getLastAttributionId for the call {}", [attributionId]);
+            return
+        }
         log.debug("handleClaimReferralReward: Attribution {} claimed", [attributionId])
         attribution.claimed = true;
-        attribution.save()
-        i++
-        attributionId = getAttributionID(call.transaction.from, call.inputs._referral, i.toString())
-        attribution = Attribution.load(attributionId);
+        attribution.save();
     }
 }
 

--- a/packages/subgraph/src/mappings/Manager.ts
+++ b/packages/subgraph/src/mappings/Manager.ts
@@ -1,0 +1,26 @@
+import { log } from '@graphprotocol/graph-ts';
+import { Attribution } from '../types/schema';
+import { ClaimReferralRewardCall, DistributeRewardsCall } from '../types/templates/Manager/Manager';
+import { getAttributionID, getOrCreateManager } from './utils/helpers';
+
+
+export function handleClaimReferralReward(call: ClaimReferralRewardCall): void {
+    let i = 0;
+    let attributionId = getAttributionID(call.transaction.from, call.inputs._referral, i.toString())
+    let attribution = Attribution.load(attributionId);
+    while (attribution !== null) {
+        log.debug("handleClaimReferralReward: Attribution {} claimed", [attributionId])
+        attribution.claimed = true;
+        attribution.save()
+        i++
+        attributionId = getAttributionID(call.transaction.from, call.inputs._referral, i.toString())
+        attribution = Attribution.load(attributionId);
+    }
+}
+
+export function handleDistributeRewards(call: DistributeRewardsCall): void {
+    let manager = getOrCreateManager(call.to);
+    manager.claimed = true;
+    manager.save()
+    log.debug("handleDistributeRewards: Rewards for manager {} distributed", [manager.id]);
+}

--- a/packages/subgraph/src/mappings/Market.ts
+++ b/packages/subgraph/src/mappings/Market.ts
@@ -2,7 +2,7 @@ import { log, BigInt, Address, dataSource } from '@graphprotocol/graph-ts';
 import { BetReward, FundingReceived, ManagementReward, PlaceBet, QuestionsRegistered, Prizes, Market as MarketContract, Attribution as AttributionEvent, Transfer, RankingUpdated } from '../types/templates/Market/Market';
 import { Manager as ManagerContract } from '../types/templates/Market/Manager'
 import { Bet, Funder, Event, Market, Attribution } from '../types/schema';
-import {getBetID, getOrCreateManager, getOrCreatePlayer, getOrCreateMarketCuration, getOrCreateMarketFactory, getAttributionID, getLastAttributionId} from './utils/helpers';
+import {getBetID, getOrCreateManager, getOrCreatePlayer, getOrCreateMarketCuration, getOrCreateMarketFactory, getAttributionID, getLastAttributionId, getOrCreateMarketReferral} from './utils/helpers';
 
 export function handleQuestionsRegistered(evt: QuestionsRegistered): void {
     // Start indexing the market; `event.params.market` is the
@@ -186,6 +186,13 @@ export function handleAttribution(evt: AttributionEvent): void {
 
     provider.totalAttributions = provider.totalAttributions.plus(attriibutionAmount);
     provider.save();
+
+    let mr = getOrCreateMarketReferral(market.id, provider.id, manager.toHexString());
+    let attributions = mr.attributions
+    attributions.push(attribution.id)
+    mr.attributions = attributions
+    mr.totalAmount = mr.totalAmount.plus(attribution.amount);
+    mr.save()
 }
 
 export function handleTransfer(evt: Transfer): void {

--- a/packages/subgraph/src/mappings/MarketFactory.ts
+++ b/packages/subgraph/src/mappings/MarketFactory.ts
@@ -2,10 +2,7 @@ import { Address, BigInt, DataSourceContext, log } from '@graphprotocol/graph-ts
 import { Manager, Market } from '../types/templates';
 import { NewMarket, CreateMarketCall } from '../types/MarketFactory/MarketFactory';
 import { Market as MarketSC } from '../types/templates/Market/Market';
-import { Event } from '../types/schema';
-import { Realitio } from '../types/RealitioV3/Realitio';
-import { RealitioAddress } from './utils/constants';
-import { getOrCreateMarketFactory } from './utils/helpers';
+import { getOrCreateEvent, getOrCreateMarketFactory } from './utils/helpers';
 
 export function handleNewMarket(evt: NewMarket): void {
   // Start indexing the market; `event.params.market` is the
@@ -28,7 +25,6 @@ export function handleCreateMarket(call: CreateMarketCall): void {
   log.debug("handleCreateMarket: call for create Market", []);
   const marketAddress = call.outputs.value0;
   const marketSC = MarketSC.bind(marketAddress);
-  let realitioSC = Realitio.bind(Address.fromBytes(RealitioAddress));
   let nonce = 0;
   while (true) {
     let questionID = marketSC.try_questionIDs(BigInt.fromI32(nonce));
@@ -36,29 +32,8 @@ export function handleCreateMarket(call: CreateMarketCall): void {
       log.warning("handleCreateMarket: questionID ask reverted. Breaking while", [])
       break;
     };
-    let event = new Event(questionID.value.toHexString());
-    event.market = marketAddress.toHexString();
-    event.nonce = BigInt.fromI32(nonce);
-    event.arbitrator = realitioSC.getArbitrator(questionID.value);
-    event.openingTs = realitioSC.getOpeningTS(questionID.value);
-    event.timeout = realitioSC.getTimeout(questionID.value);
-    event.minBond = realitioSC.getMinBond(questionID.value);
-    event.bounty = realitioSC.getBounty(questionID.value);
-    event.lastBond = BigInt.fromI32(0);
-    event.finalizeTs = realitioSC.getFinalizeTS(questionID.value);
-    event.contentHash = realitioSC.getContentHash(questionID.value);
-    event.historyHash = realitioSC.getHistoryHash(questionID.value);
-    event.arbitrationOccurred = false;
-    event.isPendingArbitration = false;
-    let data = call.inputs.questionsData[nonce];
-    let questionText = data.question;
-    let fields = questionText.split('\u241f');
-    event.title = fields[0];
-    let outcomes = fields[1].split('"').join('').split(',');
-    event.outcomes = outcomes;
-    event.category = fields[2];
-    event.lang = fields[3];
-    event.save();
+    let questionData = call.inputs.questionsData[nonce];
+    getOrCreateEvent(questionID.value, marketAddress, BigInt.fromI32(nonce), questionData.question);
     log.debug("handleCreateMarket: event {} for nonce {} created", [questionID.value.toHexString(), nonce.toString()]);
     nonce++
   }

--- a/packages/subgraph/src/mappings/MarketFactory.ts
+++ b/packages/subgraph/src/mappings/MarketFactory.ts
@@ -1,5 +1,5 @@
 import { Address, BigInt, DataSourceContext, log } from '@graphprotocol/graph-ts';
-import { Market } from '../types/templates';
+import { Manager, Market } from '../types/templates';
 import { NewMarket, CreateMarketCall } from '../types/MarketFactory/MarketFactory';
 import { Market as MarketSC } from '../types/templates/Market/Market';
 import { Event } from '../types/schema';
@@ -19,6 +19,9 @@ export function handleNewMarket(evt: NewMarket): void {
   let mf = getOrCreateMarketFactory(evt.address.toHexString());
   mf.numOfMarkets = mf.numOfMarkets.plus(BigInt.fromI32(1));
   mf.save();
+
+  // Start indexing the manager contract
+  Manager.create(evt.params.manager);
 }
 
 export function handleCreateMarket(call: CreateMarketCall): void {

--- a/packages/subgraph/src/mappings/utils/helpers.ts
+++ b/packages/subgraph/src/mappings/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Address, BigInt, ByteArray } from "@graphprotocol/graph-ts";
-import {Player, Manager, Bet, Registry, MarketCuration, Event, MarketFactory} from "../../types/schema";
+import {Player, Manager, Bet, Registry, MarketCuration, Event, MarketFactory, Attribution} from "../../types/schema";
 
 export function getBetID(market: ByteArray, tokenID: BigInt): string {
     return market.toHexString() + '-' + tokenID.toString();
@@ -53,9 +53,26 @@ export function getOrCreateMarketCuration(hash: string): MarketCuration {
     return marketCuration
 }
 
-export function getAttributionID(player:Address, attributor:Address, id:string): string {
-    return player.toHexString() + "-" + attributor.toHexString() + "-" + id;
+export function getAttributionID(player:string, attributor:string, id:number): string {
+    const playerId = player.toString();
+    const attributorId = attributor.toString();
+    return playerId + "-" + attributorId + "-" + `${id}`;
 
+}
+
+export function getLastAttributionId(player:string, attributor:string): number {
+    let i = 0;
+    let attributionId = getAttributionID(player, attributor, i)
+    let attribution = Attribution.load(attributionId);
+    if (attribution === null) return 0;
+    while (attribution !== null) {
+        i++
+        attributionId = getAttributionID(player, attributor, i)
+        attribution = Attribution.load(attributionId);
+    }
+    // return the last valid attribution index
+    i--
+    return i;
 }
 
 export function getCurrentRanking(market: ByteArray): Bet[] {

--- a/packages/subgraph/src/mappings/utils/helpers.ts
+++ b/packages/subgraph/src/mappings/utils/helpers.ts
@@ -1,5 +1,5 @@
-import { Address, BigInt, ByteArray } from "@graphprotocol/graph-ts";
-import {Player, Manager, Bet, Registry, MarketCuration, Event, MarketFactory, Attribution} from "../../types/schema";
+import { Address, BigInt, ByteArray, log } from "@graphprotocol/graph-ts";
+import {Player, Manager, Bet, Registry, MarketCuration, Event, MarketFactory, Attribution, MarketReferral} from "../../types/schema";
 
 export function getBetID(market: ByteArray, tokenID: BigInt): string {
     return market.toHexString() + '-' + tokenID.toString();
@@ -73,6 +73,22 @@ export function getLastAttributionId(player:string, attributor:string): number {
     // return the last valid attribution index
     i--
     return i;
+}
+
+export function getOrCreateMarketReferral(market:string, player:string, manager:string): MarketReferral {
+    let id = market + "-" + player;
+    let mr = MarketReferral.load(id);
+    if (mr === null) {
+        mr = new MarketReferral(id);
+        mr.totalAmount = BigInt.fromI32(0);
+        mr.market = market;
+        mr.provider = player;
+        mr.manager = manager;
+        mr.claimed = false;
+        mr.save()
+        log.debug("getOrCreateMarketReferral: Creating {}", [id]);
+    }
+    return mr
 }
 
 export function getCurrentRanking(market: ByteArray): Bet[] {

--- a/packages/subgraph/src/mappings/utils/helpers.ts
+++ b/packages/subgraph/src/mappings/utils/helpers.ts
@@ -29,6 +29,7 @@ export function getOrCreateManager(address: Address): Manager {
     if (manager === null) {
         manager = new Manager(address.toHexString())
         manager.managementRewards = BigInt.fromI32(0)
+        manager.claimed = false;
         manager.save()
     }
     return manager
@@ -50,6 +51,11 @@ export function getOrCreateMarketCuration(hash: string): MarketCuration {
         marketCuration.save()
     }
     return marketCuration
+}
+
+export function getAttributionID(player:Address, attributor:Address, id:string): string {
+    return player.toHexString() + "-" + attributor.toHexString() + "-" + id;
+
 }
 
 export function getCurrentRanking(market: ByteArray): Bet[] {

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -104,6 +104,8 @@ templates:
         - Player
         - Event
         - Manager
+        - MarketReferral
+        - Attributions
       abis:
         - name: Market
           file: ./contracts/abis/Market.json
@@ -140,6 +142,8 @@ templates:
       file: ./src/mappings/Manager.ts
       entities:
         - Manager
+        - MarketReferral
+        - Attributions
       abis:
         - name: Manager
           file: ./contracts/abis/Manager.json

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -128,3 +128,23 @@ templates:
           handler: handleTransfer
         - event: RankingUpdated(indexed uint256,uint256,uint256)
           handler: handleRankingUpdated
+  - name: Manager
+    kind: ethereum/contract
+    network: xdai
+    source:
+      abi: Manager
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mappings/Manager.ts
+      entities:
+        - Manager
+      abis:
+        - name: Manager
+          file: ./contracts/abis/Manager.json
+      callHandlers:
+        - function: claimReferralReward(address)
+          handler: handleClaimReferralReward
+        - function: distributeRewards()
+          handler: handleDistributeRewards


### PR DESCRIPTION
Changes in subgraph
- Tracks the manager and referral rewards from manager contract
- Support duplicate markets (same hash). Events now has field markets instead of market <- this change brakes the UI.
Changes in frontend
- Fix useEvents to support the change in the subgraph
- Add a button to claim the referrals rewards in the profile view. 