### PR TITLE
Feat/delete markets

### DIFF
--- a/packages/react-app/src/hooks/useMarket.ts
+++ b/packages/react-app/src/hooks/useMarket.ts
@@ -19,10 +19,6 @@ export const useMarket = (marketId: string) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      if (response.data.market.deleted) {
-        return;
-      }
-
       return response.data.market;
     }
   );

--- a/packages/react-app/src/hooks/useMarkets.ts
+++ b/packages/react-app/src/hooks/useMarkets.ts
@@ -27,7 +27,7 @@ export const useMarkets = ({curated, status, category, minEvents, creatorId}: Us
   return useQuery<Market[], Error>(
     ["useMarkets", curated, status, category, minEvents, creatorId],
     async () => {
-      const variables: QueryVariables = {curated, deleted: false, orderDirection: 'desc'};
+      const variables: QueryVariables = {curated, orderDirection: 'desc'};
 
       if (category) {
         variables['category_in'] = [category, ...getSubcategories(category).map(s => s.id)];

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -25,7 +25,6 @@ type Market @entity {
   protocolFee: BigInt!
   manager: Manager!
   creator: String!
-  deleted: Boolean!
   numOfEvents: BigInt!
   numOfEventsWithAnswer: BigInt!
   hasPendingAnswers: Boolean!

--- a/packages/subgraph/src/mappings/KeyValue.ts
+++ b/packages/subgraph/src/mappings/KeyValue.ts
@@ -1,4 +1,4 @@
-import { log, BigInt } from '@graphprotocol/graph-ts';
+import { log, BigInt, store } from '@graphprotocol/graph-ts';
 import { SetValue } from '../types/KeyValue/KeyValue'
 import { Market } from '../types/schema';
 
@@ -13,8 +13,8 @@ export function handleSetValue(evt: SetValue): void {
         }
 
         if (market.creator == evt.transaction.from.toHexString() && market.pool.equals(BigInt.fromI32(0))) {
-            market.deleted = true;
-            market.save();
+            log.debug("handleSetValue: Deleting event {} ", [market.id]);
+            store.remove("Market", market.id);
         }
     }
 }

--- a/packages/subgraph/src/mappings/Market.ts
+++ b/packages/subgraph/src/mappings/Market.ts
@@ -32,7 +32,6 @@ export function handleQuestionsRegistered(evt: QuestionsRegistered): void {
     let manager = getOrCreateManager(creator);
     market.manager = manager.id;
     market.creator = evt.transaction.from.toHexString();
-    market.deleted = false;
     market.numOfEvents = BigInt.fromI32(evt.params._questionIDs.length);
     let event = Event.load(evt.params._questionIDs[0].toHexString())
     if (event === null) {


### PR DESCRIPTION
Remove "deleted" field from the market entity in the subgraph. Change the behavior of the subgraph to delete the entity when the event of deleteMarket it's called in the KeyValue SmartContract