### PR TITLE
subgraph: add fullTextSearch with Market Title field

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -191,3 +191,11 @@ type MarketFactory @entity {
   totalVolumeFunding: BigInt!
   markets: [Market!]! @derivedFrom(field: "marketFactory")
 }
+
+type _Schema_
+  @fulltext(
+    name: "marketTitleSearch"
+    language: en
+    algorithm: rank
+    include: [{ entity: "Market", fields: [{ name: "name" }] }]
+  )

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -3,6 +3,8 @@ description: Subgraph that tracks markets data
 repository: https://github.com/prodeapp/prodeapp
 schema:
   file: ./schema.graphql
+features:
+  - fullTextSearch
 dataSources:
   - kind: ethereum/contract
     name: MarketFactory


### PR DESCRIPTION
This feature enables searches by market title in the subgraph.

For example if we want to get all the FIFA markets, we can query the subgraph with:

```
query {
  marketTitleSearch(text: "FIFA") {
    id
    name
  }
}
```